### PR TITLE
Game Match changes, blinky font-size transition, more card score fiddling.

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -11,7 +11,7 @@ html {
 body {
   background-color: #3f5467;
   font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
-  font-size: 1em;
+  font-size: 1rem;
   padding: 0 2% 1% 2%;
 }
 
@@ -57,16 +57,28 @@ li {
   margin: 4px 2px;
   text-align: center;
   vertical-align: middle;
-  font-size: 1.75em;
+  font-size: 1.75rem;
   background-size: 100% 200%;
   background-position: 0 0;
   background-image: linear-gradient(to bottom, lightblue 50%, white 50%);
   transition: background-position 0.3s, color 0.3s;
 }
 
+.card-contents {
+  display: flex;
+  flex-flow: column wrap;
+  display: -webkit-flex;
+  -webkit-flex-flow: column wrap;
+}
+
+.icon {
+  flex-basis: 100%;
+  -webkit-flex-basis: 100%;
+}
+
 .tiny-score {
-  margin: -10px;
-  font-size: 0.5em;
+  font-size: 1rem;
+  margin: 0;
 }
 
 .scoreboard {
@@ -74,10 +86,6 @@ li {
   border-radius: 5px;
   padding: 0;
   margin: 0;
-}
-
-.waiting-queue {
-  /*background: lightblue;*/
 }
 
 li.turned-down {
@@ -121,11 +129,16 @@ header.head-container {
 .match-container {
   display: inline-block;
   vertical-align: top;
-  width: 49%;
+  width: 48%;
   background-color: white;
   border-radius: 5px;
   color: #5C5C5C;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1rem 0.8rem;
+  min-height: 130px;
+}
+
+.match-container:first-of-type{
+  margin-right: 1%;
 }
 
 .match-container h3{
@@ -160,12 +173,10 @@ header.head-container {
 }
 
 .scoreboard-p0, .scoreboard-p1{
-  flex-basis: 8rem;
-  -webkit-flex-basis: 8rem;
+  flex-basis: 10rem;
+  -webkit-flex-basis: 10rem;
   align-self: center;
   -webkit-align-self: center;
-  padding: 10px;
-  text-align: center;
   margin: 0.2rem auto 0.5rem;
 }
 
@@ -188,8 +199,23 @@ header.head-container {
 }
 
 
+/*GameControl*/
+.queue-message {
+  color: #EFEFEF;
+}
+
+.waiting-queue{
+  text-align: center;
+  max-width: 440px;
+  padding: 13px 8px 15px;
+  background-color: white;
+  border-radius: 5px;
+  margin-bottom: 5px;
+}
+
+
 /*Media query to re-order flexboxes*/
-@media(max-width: 915px) {
+@media(max-width: 975px) {
   .grid-container{
     flex-basis: 100%;
     order: 1;
@@ -211,9 +237,20 @@ header.head-container {
 }
 
 
-/*Make blink animation!*/
+/*Score transitions and animations*/
+.score {
+  line-height: 30px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  transition: font-size 0.6s;
+}
+
+.alert-blink.score{
+  font-size: 1.4rem;
+  transition: font-size 0.6s;
+}
+
 .alert-blink {
-  /*display: inline-block;*/
   color: red;
   animation: color 1s infinite;
   animation-direction: alternate;

--- a/client/styles/normalize.css
+++ b/client/styles/normalize.css
@@ -1,0 +1,424 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  box-sizing: content-box; /* 2 */
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}

--- a/client/templates/gameControl/gameContol.html
+++ b/client/templates/gameControl/gameContol.html
@@ -7,7 +7,7 @@
     </section>
     {{else}}
     <input type=button id='newGame' value='Queue up a new game'>
-    <p>Or click a queued game below to join in.</p>
+    <h4 class="queue-message">Or click a queued game below to join in.</h4>
     {{#each gamesWaiting}}
       <p id='{{_id}}' class='waiting-queue'>
         <i class="fa fa-toggle-right"></i> Waiting for challenger. (Game created at {{formatDate timestamp 'LT'}})

--- a/client/templates/grid/grid.html
+++ b/client/templates/grid/grid.html
@@ -3,8 +3,10 @@
     <ul>
       {{#each shuffledCards}}
         <li id='grid-{{idx}}' class='{{class}}'>
-          <div class='icon-{{val}}'></div>
-          <div class='tiny-score'>{{score}}</div>
+          <div class="card-contents">
+            <div class='icon icon-{{val}}'></div>
+            <div class='tiny-score'>{{score}}</div>
+          </div>
         </li>
       {{/each}}
     </ul>

--- a/client/templates/matches/matches.html
+++ b/client/templates/matches/matches.html
@@ -1,20 +1,22 @@
 <template name='Matches'>
     {{#with scoreBoard}}
   <section class="scoreboard scoreboard-p0">
-      <div class="player{{my.playerIdx}} {{whoseTurn my.turn}}">{{my.name}}: {{my.score}}</div>
+      <div class="score player{{my.playerIdx}} {{whoseTurn my.turn}}">{{my.name}}: {{my.score}}</div>
   </section>
   <section class="scoreboard scoreboard-p1">
-      <div class="player{{your.playerIdx}} {{whoseTurn your.turn}}">{{your.name}}: {{your.score}}</div>
+      <div class="score player{{your.playerIdx}} {{whoseTurn your.turn}}">{{your.name}}: {{your.score}}</div>
   </section>
-    
+
   <div class="matches">
     <section class='match-container my-matches'>
       <h3>My Matches</h3>
       <ul class="scoreboard">
         {{#each my.matches}}
           <li id='grid-{{idx}}' class='{{class}}'>
-            <span class='icon-{{val}}'></span>
-            <p class='tiny-score'>{{score}}</p>
+            <div class="card-contents">
+              <div class='icon-{{val}}'></div>
+              <div class='tiny-score'>{{score}}</div>
+            </div>
           </li>
         {{/each}}
       </ul>
@@ -24,8 +26,10 @@
       <ul class="scoreboard">
         {{#each your.matches}}
           <li id='grid-{{idx}}' class='{{class}}'>
-            <span class='icon-{{val}}'></span>
-            <p class='tiny-score'>{{score}}</p>
+            <div class="card-contents">
+              <div class='icon-{{val}}'></div>
+              <div class='tiny-score'>{{score}}</div>
+            </div>
           </li>
         {{/each}}
       </ul>


### PR DESCRIPTION
Hey Paul!

New changes that update the game match template styling and add a font size transition for the blinking score box. 

I also took another crack at the li score cards... let me know if they work. Now looks like:

```
<li id='grid-{{idx}}' class='{{class}}'>
  <div class="card-contents">
    <div class='icon-{{val}}'></div>
    <div class='tiny-score'>{{score}}</div>
  </div>
</li>
```

Where the .card-contents div wrapper uses display:flex . I... hope it works.
